### PR TITLE
Fixes and adds

### DIFF
--- a/VisualStudio/ExceptionTemplate.snippet
+++ b/VisualStudio/ExceptionTemplate.snippet
@@ -1,0 +1,33 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<CodeSnippets  xmlns="http://schemas.microsoft.com/VisualStudio/2005/CodeSnippet">
+	<CodeSnippet Format="1.0.0">
+		<Header>
+			<Title>Exception template</Title>
+			<Description>Starting point for writing a custom application exception</Description>
+			<Author>Eli Hayon</Author>
+			<Shortcut>extem</Shortcut>
+			<SnippetTypes>
+				<SnippetType>Expansion</SnippetType>
+			</SnippetTypes>
+		</Header>
+		<Snippet>
+			<Code Language="csharp"><![CDATA[public class MyException
+	: Exception
+{
+	public MyException()
+		: base(GetMessage("arguments"))
+	{
+
+	}
+
+	private static string GetMessage(string myArguments)
+	{
+		var str = myArguments + "Pass as many arguments as needed to construct a meaningful message.";
+
+		return str;
+	}
+}]]>
+			</Code>
+		</Snippet>
+	</CodeSnippet>
+</CodeSnippets>

--- a/VisualStudio/UniqueMessageAddress.snippet
+++ b/VisualStudio/UniqueMessageAddress.snippet
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<CodeSnippets  xmlns="http://schemas.microsoft.com/VisualStudio/2005/CodeSnippet">
+	<CodeSnippet Format="1.0.0">
+		<Header>
+			<Title>Unique message address</Title>
+			<Description>Use when you need to know where a message originated. Unique identifier that is human readable will be easy to find in code.</Description>
+			<Author>Eli Hayon</Author>
+			<Shortcut>messageAddress</Shortcut>
+			<SnippetTypes>
+				<SnippetType>Expansion</SnippetType>
+			</SnippetTypes>
+		</Header>
+		<Snippet>
+			<!-- https://code.visualstudio.com/docs/editor/userdefinedsnippets - doesn't work as expected sadly. Keeping this for the future just in case. -->
+			<Code Language="csharp"><![CDATA[ var blah = "0x$CURRENT_YEAR$CURRENT_MONTH$CURRENT_DATE$CURRENT_HOUR$CURRENT_MINUTE$CURRENT_SECOND"; ]]></Code>
+		</Snippet>
+	</CodeSnippet>
+</CodeSnippets>

--- a/VisualStudio/UnitTestAssertThrows.snippet
+++ b/VisualStudio/UnitTestAssertThrows.snippet
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<CodeSnippets  xmlns="http://schemas.microsoft.com/VisualStudio/2005/CodeSnippet">
+	<CodeSnippet Format="1.0.0">
+		<Header>
+			<Title>Unit test Assert.Throws</Title>
+			<Description>Stub code for writing the Assert.Throws syntax</Description>
+			<Author>Eli Hayon</Author>
+			<Shortcut>throws</Shortcut>
+			<SnippetTypes>
+				<SnippetType>Expansion</SnippetType>
+				<SnippetType>SurroundsWith</SnippetType>
+			</SnippetTypes>
+		</Header>
+		<Snippet>
+			<Code Language="csharp"><![CDATA[Assert.Throws<MyException>(() => { $selected$ });]]>
+			</Code>
+		</Snippet>
+	</CodeSnippet>
+</CodeSnippets>

--- a/VisualStudio/UnitTestSetupComment.snippet
+++ b/VisualStudio/UnitTestSetupComment.snippet
@@ -3,24 +3,15 @@
   <CodeSnippet Format="1.0.0">
     <Header>
       <Title>Unit test setup</Title>
+	  <Description>Insert basic Unit Testing setup questions 1. Arrange 2. Act 3. Assert as comments in the body of a unit test</Description>
       <Author>Eli Hayon</Author>
-      <Description>Insert basic Unit Testing setup questions 1. Arrange 2. Act 3. Assert as comments in the body of a unit test</Description>
       <Shortcut>aaa</Shortcut>
 	  <SnippetTypes>
 		<SnippetType>Expansion</SnippetType>
-		<SnippetType>SurroundsWith</SnippetType>
 	  </SnippetTypes>
     </Header>
     <Snippet>
-      <Imports>
-        <Import>
-          <Namespace/>
-        </Import>
-      </Imports>
-      <Declarations>
-        <Literal/>
-      </Declarations>
-      <Code Language="C#" Kind="method body"><![CDATA[//Arrange
+        <Code Language="csharp"><![CDATA[//Arrange
 
 
 //Act


### PR DESCRIPTION
Fixed the UnitTestSetupComment snippet, it wasn't being recognized by Visual Studio. Added a few more snippet samples. The UniqeMessageAddress snippet does not work but I am keeping it for the future if it works then. Currently a limitation of Visual Studio's snippet tool.